### PR TITLE
Fix span inline attribute lists in code blocks

### DIFF
--- a/lib/htmlGenerator.js
+++ b/lib/htmlGenerator.js
@@ -276,6 +276,9 @@ customRenderer.heading = function(text, level, raw) {
 };
 customRenderer.code = function(code, lang, escaped) {
 	var result = marked.Renderer.prototype.code.call(this, code, lang, escaped);
+	var dom = common.htmlToDom(result)[0];
+	applySpanAttributes(dom);
+	result = common.domToHtml(dom);
 	var token = tokensStack.pop();
 	result = applyToken(result, token);
 	return invokeExtensions("html.onCode", result, {src: token.src});


### PR DESCRIPTION
This PR adds a small fix for applying span IALs to code blocks. The syntax I've followed for applying them comes from [kramdown](https://kramdown.gettalong.org/syntax.html#span-ials).

For the most part, applying these works fine, but there's a specific case I've found where it fails, which I'll detail below, both for clarity's sake and because I'm admittedly not very familiar with this repo, in case I've gone about this the wrong way 🙃

## What works
We have some attributes defined at the top of the original markdown file, highlighted here:

![screen shot 2018-10-31 at 1 33 33 pm](https://user-images.githubusercontent.com/8710772/47807999-d441cf80-dd13-11e8-8ef9-00554b35faf9.png)

This next example shows it working fine with the current HTML generation code. We have the attributes used in the markdown:

![screen shot 2018-10-31 at 1 34 08 pm](https://user-images.githubusercontent.com/8710772/47808101-0b17e580-dd14-11e8-8c4e-f8e08878bc8b.png)

which shows up as expected in the generated HTML, with the attributes hidden and applied to the HTML `span` elements:

![screen shot 2018-10-31 at 1 35 01 pm](https://user-images.githubusercontent.com/8710772/47808277-64801480-dd14-11e8-966c-13efa9f4b287.png)

## The issue
The problem arises when the code block isn't indented like in the above example. In that case, we get unwanted behavior.

Markdown:

![screen shot 2018-10-31 at 1 33 57 pm](https://user-images.githubusercontent.com/8710772/47808326-82e61000-dd14-11e8-82d2-92711f087248.png)

HTML:

![screen shot 2018-10-31 at 1 36 34 pm](https://user-images.githubusercontent.com/8710772/47808436-c50f5180-dd14-11e8-8b24-85ed3cba43dc.png)

## Solution
With the 3 lines added in this PR and no additional tweaks to the markdown, we get the HTML we're looking for:

![screen shot 2018-10-31 at 1 35 20 pm](https://user-images.githubusercontent.com/8710772/47808637-2800e880-dd15-11e8-84bc-3734a018cec0.png)
