### PR TITLE
feat(toc): Enable toc generators to access frontMatter from md

### DIFF
--- a/lib/marked-it.js
+++ b/lib/marked-it.js
@@ -75,7 +75,7 @@ function generate(source, options) {
 	var jsonGenerator;
 	if (options.tocJSON) {
 		adapter = new tocJSONadapter(extensions);
-		jsonGenerator = new tocJSONgenerator(adapter, options.filePath, options.tocDepth || Infinity);
+		jsonGenerator = new tocJSONgenerator(adapter, options.filePath, options.tocDepth || Infinity, frontMatterMap);
 		tocGenerators.push(jsonGenerator);
 	}
 

--- a/lib/tocJSONadapter.js
+++ b/lib/tocJSONadapter.js
@@ -62,10 +62,14 @@ tocJSONadapter.prototype = {
 	createRoot: function() {
 		return {};
 	},
-	createTopic: function(href, label, id, heading) {
+	createTopic: function(href, label, id, heading, optionalAttrs) {
 		var object = {href: href, label: label};
+		const { lastUpdated } = optionalAttrs;
 		if (id) {
 			object.id = id;
+		}
+		if (lastUpdated) {
+			object.lastUpdated = lastUpdated;
 		}
 		return common.invokeExtensions(
 			this.extensions,

--- a/lib/tocJSONgenerator.js
+++ b/lib/tocJSONgenerator.js
@@ -24,7 +24,7 @@
 
 var common = require("./common");
 
-module.exports = function(callbacks, urlPrefix, tocDepth) {
+module.exports = function(callbacks, urlPrefix, tocDepth, frontMatterMap) {
 	var dom = {toc:{}};
 
 	var stack = [dom.toc]; /* a basic stack to represent TOC tree structure */
@@ -67,7 +67,11 @@ module.exports = function(callbacks, urlPrefix, tocDepth) {
 //						}
 //					});
 //				}
-				var newElementText = callbacks.createTopic(urlPrefix + "#" + attributes.id, text, attributes.id, heading);
+				const optionalAttrs = {};
+				if (level === 1) {
+					optionalAttrs.lastUpdated = frontMatterMap.lastupdated
+				}
+				var newElementText = callbacks.createTopic(urlPrefix + "#" + attributes.id, text, attributes.id, heading, optionalAttrs);
 				if (newElementText) {
 					newElement = JSON.parse(newElementText);
 					if (!parent.topics) {


### PR DESCRIPTION
Pass frontMatter to topic generation in toc generator and adapter, and enable additional attributes to be used in the future. For now, add lastUpdated to the top (level 1) topic.

For https://github.com/IBM/marked-it-cli/issues/20